### PR TITLE
修改一个文件定位错误

### DIFF
--- a/docs/lifecycle/templateComplie.md
+++ b/docs/lifecycle/templateComplie.md
@@ -87,7 +87,7 @@ Vue.prototype.$mount = function (el,hydrating) {
 
 ### 2.2 完整版的vm.$mount方法分析
 
-完整版的`vm.$mount`方法定义位于源码的`dist/vue.js`中，如下：
+完整版的`vm.$mount`方法定义位于源码的`src/platforms/web/entry-runtime-with-compiler.js`中，如下：
 
 ```javascript
 var mount = Vue.prototype.$mount;


### PR DESCRIPTION
dist是存放构建后文件的地方，源码肯定不在这里面。用搜索找到了完整版的Vue.$mount的定义在`src/platforms/web/entry-runtime-with-compiler.js`目录下